### PR TITLE
Update website Python Barranquilla

### DIFF
--- a/all-communities.json
+++ b/all-communities.json
@@ -22,7 +22,7 @@
     {
       "name": "Python Baq",
       "logo": "/images/communities/pybaq-logo.png",
-      "website": "https://twitter.com/pybaq",
+      "website": "https://pybaq.co/",
       "background": "#002F34"
     },
     {


### PR DESCRIPTION
Se modifica el enlace de la comunidad Python Baq para que lleve al sitio web https://pybaq.co/, en el cual se encuentra toda la información centralizada.