### PR TITLE
refactor: Rename Sponsor component

### DIFF
--- a/src/components/Sponsor/index.js
+++ b/src/components/Sponsor/index.js
@@ -2,7 +2,7 @@ import classNames from 'classnames'
 import Image from 'next/image'
 import Link from 'next/link'
 
-export function Sponsors({ website, name, logo, background, className }) {
+export function Sponsor({ website, name, logo, background, className }) {
   return (
     <Link className='flex justify-start flex-col items-center w-[160px] z-10' href={website}
       target='_blank'>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,7 +5,7 @@ import { Seo } from "@/components/Seo";
 import { Layout } from "@/components/Layout";
 import { Community } from "@/components/Community";
 import { Avatar } from "@/components/Avatar";
-import { Sponsors } from "@/components/Sponsors";
+import { Sponsor } from "@/components/Sponsor";
 
 import allSocialMedia from '@/all-social-media'
 import allCommunities from "@/all-communities";
@@ -55,10 +55,10 @@ const home = ({ events }) => {
         id='communities'
         className='bg-secondary-hero relative -mt-[20px] md:-mt-[34px] pb-[30px]'
       >
-        <div className='absolute flex justify-center top-0 left-0 right-0 w-full'>
+        <div className='absolute top-0 left-0 right-0 flex justify-center w-full'>
           <ReflectedSunImage className='w-[76%] md:w-[49%]' />
         </div>
-        <div className='md:flex absolute justify-center md:top-0 left-0 right-0 w-full'>
+        <div className='absolute left-0 right-0 justify-center w-full md:flex md:top-0'>
           <ReflectedClouldsImage className='w-[100%] z-0' />
         </div>
         <Layout className='relative md:pt-16'>
@@ -74,7 +74,7 @@ const home = ({ events }) => {
             Sponsors
           </h2>
           <section className="flex flex-wrap justify-center gap-4 pt-6 md:pt-50">
-            {sponsors.map((sponsor) => <Sponsors key={sponsor.website} {...sponsor} />)}
+            {sponsors.map((sponsor) => <Sponsor key={sponsor.website} {...sponsor} />)}
           </section>
           <h2 id='organizers' className='text-[35px] md:text-[60px] mt-20 text-tertiary'>
             Fundadores
@@ -88,7 +88,7 @@ const home = ({ events }) => {
               );
             })}
           </div>
-          <div className='pt-2 flex justify-center'>
+          <div className='flex justify-center pt-2'>
             <a
               href={social[2].url}
               className='text-tertiary text-[20px] justify-center items-center rounded-2xl bg-secondary px-[60px] py-[25px] font-bold hover:opacity-90'


### PR DESCRIPTION
The `Sponsors` component was renamed to `Sponsor`. 

Now it makes sense to read the code as follows:
```js
{sponsors.map((sponsor) => <Sponsor key={sponsor.website} {...sponsor} />)}
```