### PR TITLE
feat: Show two columns for the Founders section on mobile

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -8,17 +8,17 @@ const ICON_SIZE = 22
 
 export function Avatar({ name, image, social = {} }) {
   return (
-    <div className='flex flex-col justify-between items-center w-[220px] h-[220px]'>
-      <div className='relative w-[140px] h-[140px]  avatar'>
+    <div className='flex flex-col justify-between items-center md:w-[220px] w-[165px]'>
+      <div className='relative w-[80%] md:w-[140px] aspect-square avatar'>
         <Image
-          className='object-cover my-0 mx-auto rounded-full z-0'
+          className='z-0 object-cover mx-auto my-0 rounded-full'
           src={image}
           alt={`${name} image`}
           fill
         />
       </div>
-      <span className='font-bold mt-4 text-tertiary'>{name}</span>
-      <div className='flex gap-5 mt-1 items-center'>
+      <span className='mt-4 font-bold text-tertiary'>{name}</span>
+      <div className='flex items-center gap-5 mt-1'>
         {
           social.website && (
             <a href={social.website} target='_blank'>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -55,10 +55,10 @@ const home = ({ events }) => {
         id='communities'
         className='bg-secondary-hero relative -mt-[20px] md:-mt-[34px] pb-[30px]'
       >
-        <div className='absolute flex justify-center top-0 left-0 right-0 w-full'>
+        <div className='absolute top-0 left-0 right-0 flex justify-center w-full'>
           <ReflectedSunImage className='w-[76%] md:w-[49%]' />
         </div>
-        <div className='md:flex absolute justify-center md:top-0 left-0 right-0 w-full'>
+        <div className='absolute left-0 right-0 justify-center w-full md:flex md:top-0'>
           <ReflectedClouldsImage className='w-[100%] z-0' />
         </div>
         <Layout className='relative md:pt-16'>
@@ -79,7 +79,7 @@ const home = ({ events }) => {
           <h2 id='organizers' className='text-[35px] md:text-[60px] mt-20 text-tertiary'>
             Fundadores
           </h2>
-          <div className='flex flex-wrap justify-center items-center pt-[50px]'>
+          <div className='flex flex-wrap justify-around md:justify-center items-center pt-[50px]'>
             {organizers.map(({ name, image, social }) => {
               return (
                 <div className='flex justify-center basis-[20%] mb-12' key={name}>
@@ -88,7 +88,7 @@ const home = ({ events }) => {
               );
             })}
           </div>
-          <div className='pt-2 flex justify-center'>
+          <div className='flex justify-center pt-2'>
             <a
               href={social[2].url}
               className='text-tertiary text-[20px] justify-center items-center rounded-2xl bg-secondary px-[60px] py-[25px] font-bold hover:opacity-90'


### PR DESCRIPTION
Previously, on mobile, Founders info were displayed in a single column, making the page unnecessarily long and requiring a lot of scrolling to reach the end of the page.

So, I think it is better to have two columns.

**Screenshots:**

| Now (2 columns) | Before (1 column) |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/bb29f488-8511-4999-b321-2485c494447d) | ![image](https://github.com/user-attachments/assets/3b514c3e-4849-4723-9c78-adf8f608bfeb) | 
