### PR TITLE
fix: CaribeConf button in NavBar Menu on mobile does not hide on click

### DIFF
--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -29,7 +29,7 @@ export function Menu({ className, isOpen, setOpen }) {
         <li className='font-bold text-center md:font-medium text-tertiary'>
           <Link href="/hacktoberfest/2024/index.html">HacktoberFest</Link>
         </li>
-        <li className='font-bold text-center md:font-medium text-tertiary'>
+        <li className='font-bold text-center md:font-medium text-tertiary' onClick={onClick}>
           <Link href="/caribeconf">CaribeConf</Link>
         </li>
       </ul>


### PR DESCRIPTION
When clicking the "Caribe Conf" button in NavBar, the navbar menu in mobile is not hidden. This behavour is fixed with this PR.